### PR TITLE
Support exceptions in a range of days

### DIFF
--- a/osm_time/opening_hours.py
+++ b/osm_time/opening_hours.py
@@ -75,9 +75,9 @@ def parse_string(value):
             # Complete the dict for days between beginning and end
             # e.g. Mo-Th --> Mo,Tu,We,Th
             for da in DAYS_OF_THE_WEEK[day_fr:day_t + 1]:
-                opening_hours[da].extend(process_ranges(r))
+                opening_hours[da] = process_ranges(r)
         else:
-            opening_hours[d].extend(process_ranges(r))
+            opening_hours[d] = process_ranges(r)
     return opening_hours
 
 

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -39,6 +39,16 @@ class TestOpeningDays(unittest.TestCase):
         self.assertEqual(oh.is_open("Sa", "14:00"), False)
         self.assertEqual(oh.is_open("ph", "10:00"), True)
 
+    def test_exception(self):
+        oh = OpeningHours("Mo-Fr 09:00-17:30; We 09:00-13:00; Sa 09:00-12:00")
+        self.assertEqual(oh.is_open("Mo", "14:00"), True)
+        self.assertEqual(oh.is_open("We", "12:00"), True)
+        self.assertEqual(oh.is_open("We", "14:00"), False)
+        self.assertEqual(oh.is_open("Tu", "14:00"), True)
+        self.assertEqual(oh.is_open("Sa", "11:00"), True)
+        self.assertEqual(oh.is_open("Sa", "14:00"), False)
+        self.assertEqual(oh.is_open("Su", "10:00"), False)
+
     def test_complex_value_minutes(self):
         oh = OpeningHours("Mo 10:00-12:00,12:30-15:00; Tu-Fr 08:00-12:00,12:30-15:00; Sa 08:00-12:00")
         self.assertEqual(oh.minutes_to_closing("Su", "10:00"), 0)


### PR DESCRIPTION
The opening_hours syntax supports exceptions in a range of days, such as
Mo-Sa 10:00-20:00; Tu 10:00-14:00. We need to reset the list rather than
extend it.
